### PR TITLE
barycentric coordinate calculation correction

### DIFF
--- a/include/sdf/sdf.hpp
+++ b/include/sdf/sdf.hpp
@@ -92,16 +92,17 @@ Eigen::Matrix<T, 1, 3, Eigen::RowMajor> bary(
     const Eigen::Ref<const Eigen::Matrix<T, 1, 3, Eigen::RowMajor>>& c,
     const Eigen::Ref<const Eigen::Matrix<T, 1, 3, Eigen::RowMajor>>& normal,
     float area_abc) {
-    float area_pbc = normal.dot((b - p).cross(c - p));
-    float area_pca = normal.dot((c - p).cross(a - p));
 
+    Eigen::Matrix<T, 1, 3> u = b - a;
+    Eigen::Matrix<T, 1, 3> v = c - a;
+    Eigen::Matrix<T, 1, 3> w = p - a;
+    Eigen::Matrix<T, 1, 3> n = normal;
     Eigen::Matrix<T, 1, 3> uvw;
-    uvw.x() = area_pbc / area_abc;
-    uvw.y() = area_pca / area_abc;
-    uvw.z() = T(1.0) - uvw.x() - uvw.y();
+    uvw[2] = u.cross(w).dot(n) / (area_abc + T(1e-5));
+    uvw[1] = w.cross(v).dot(n) / (area_abc + T(1e-5));
+    uvw[0] = T(1.0) - uvw[1] - uvw[2];
 
-    return uvw;
-}
+    return uvw;}
 
 template <class T>
 // 3D point to triangle shortest distance SQUARED


### PR DESCRIPTION
## Barycentric coordinate calculation

I seem to have found a problem in the barycentric coordinate calculation.

The original implementation was giving me incorrect coordinates. This seemed to not influence the "distance", and therefore might have been remained overlooked.

The correction is simple and is not adding computational time.

The calculation originates from [this math-stackexchange comment](https://math.stackexchange.com/questions/544946/determine-if-projection-of-3d-point-onto-plane-is-within-a-triangle)

Let $\overrightarrow{u} = b - a$, $\overrightarrow{v} = c - a$, $\overrightarrow{w} = p - a$ and $\overrightarrow{n} = \overrightarrow{u} \times \overrightarrow{v}$. The barycentric coordinates of $p'$, the projection of $p$ onto the plane $(a,b,c)$ are therefore:

$$ \gamma = \[\(\overrightarrow{u} \times \overrightarrow{w} \) \cdot \overrightarrow{n} \] / \| \overrightarrow{n} \|^2 $$

$$ \beta = \[\(\overrightarrow{w} \times \overrightarrow{v} \) \cdot \overrightarrow{n} \] / \| \overrightarrow{n} \|^2 $$

$$ \alpha = 1 - \beta - \gamma$$

The coordinates of the projected point is

$$ p' = \alpha a+ \beta b + \gamma c $$
