### PR TITLE
Fix deprecated/invalid `setup.cfg` (breaks on setuptools>=78)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Support for dash-separated options in `setup.cfg` has been deprecated since [Setuptools v54.1.0 (05 Mar 2021)](https://setuptools.pypa.io/en/latest/history.html#id855).