### PR TITLE
fix: add missing #include <chrono> for std::chrono::high_resolution_c…

### DIFF
--- a/include/sdf/internal/sdf_util.hpp
+++ b/include/sdf/internal/sdf_util.hpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <functional>
 #include <thread>
 #include <random>


### PR DESCRIPTION
…lock

util.cpp's get_rng() calls std::chrono::high_resolution_clock::now() but sdf_util.hpp (its only relevant include chain) never includes <chrono>. This compiled for years because <random>/<thread> used to transitively leak <chrono> on most standard libraries; newer MSVC STL releases tightened header hygiene and stopped leaking it, causing a hard build failure on Windows with recent toolsets (error C2039: 'high_resolution_clock' is not a member of 'std::chrono'). One-line fix, no behavior change.